### PR TITLE
Try to get stream URL from API response 

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ def record_twitcasting(user, proxy='', user_agent='', filename=''):
 
         try:
             # Default filename
-            filename = filename if filename else datetime.now().strftime('record_%Y%m%d_%H%M%S.ts')
+            filename = filename if filename else datetime.now().strftime('record_' + user + '_%Y%m%d_%H%M%S.ts')
 
             output_fd = open(filename, 'wb')
             print(f'Writing stream to {filename}')
@@ -97,15 +97,12 @@ def get_stream_url(user, proxy='', user_agent=''):
         return
 
     try: 
-        if 'main' == mode: 
-            stream_url = data['llfmp4']['streams']['main']
-        elif 'base' == mode: 
-            stream_url = data['llfmp4']['streams']['base']
+        stream_url = data['llfmp4']['streams']['main']
     except: 
          # fallback 
          # 1st number variable: 0 - no compression, 1 - compression
          # 2nd number variable: bufferOffset  
-        stream_url = f'{proto}://{host}/ws.app/stream/{movie_id}/fmp4/bd/0/0?mode={mode}'
+        stream_url = f'{proto}://{host}/ws.app/stream/{movie_id}/fmp4/bd/1/1500?mode={mode}'
     return stream_url
 
 

--- a/main.py
+++ b/main.py
@@ -96,7 +96,16 @@ def get_stream_url(user, proxy='', user_agent=''):
         print(f'No stream available for user {user}')
         return
 
-    stream_url = f'{proto}://{host}/ws.app/stream/{movie_id}/fmp4/bd/1/1500?mode={mode}'
+    try: 
+        if 'main' == mode: 
+            stream_url = data['llfmp4']['streams']['main']
+        elif 'base' == mode: 
+            stream_url = data['llfmp4']['streams']['base']
+    except: 
+         # fallback 
+         # 1st number variable: 0 - no compression, 1 - compression
+         # 2nd number variable: bufferOffset  
+        stream_url = f'{proto}://{host}/ws.app/stream/{movie_id}/fmp4/bd/0/0?mode={mode}'
     return stream_url
 
 


### PR DESCRIPTION
I have noticed that `streamserver.php` API sometimes returns full stream URL in `llfmp4` section. We can try to make use of that URL. 
Also we can add username in the recording filename to better distinguish the recordings. 